### PR TITLE
Update AWS CLI to V2 (Old version causes a build issue where aws executable failed to run).

### DIFF
--- a/awscli.nuspec
+++ b/awscli.nuspec
@@ -11,10 +11,10 @@
         <iconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</iconUrl>
         <tags>automation deployment</tags>
         <contentFiles>
-            <files include=".\Amazon\AWSCLI\**\" buildAction="None" copyToOutput="false" />
+            <files include=".\Amazon\AWSCLIV2\**\" buildAction="None" copyToOutput="false" />
         </contentFiles>
     </metadata>
     <files>
-        <file src=".\Amazon\AWSCLI\**\" target="AWSCLI" />
+        <file src=".\Amazon\AWSCLIV2\**\" target="AWSCLIV2" />
     </files>
 </package>

--- a/build.cake
+++ b/build.cake
@@ -21,8 +21,7 @@ var buildDir = @".\build";
 var unpackFolder = Path.Combine(buildDir, "temp");
 var unpackFolderFullPath = Path.GetFullPath(unpackFolder);
 var artifactsDir = @".\artifacts";
-var files = new string[] { "AWSCLI64.msi", "AWSCLI32.msi" };
-var file = string.Empty;
+var file = "AWSCLIV2.msi";
 var nugetVersion = string.Empty;
 var nugetPackageFile = string.Empty;
 
@@ -63,7 +62,7 @@ Task("Restore-Source-Package")
     .Does(() => 
 {
     var outputPath = File($"{buildDir}/{file}");
-    var url = $"https://s3.amazonaws.com/aws-cli/{file}";
+    var url = $"https://awscli.amazonaws.com/{file}";
     Information($"Downloading {url}");
     DownloadFile(url, outputPath);
 });
@@ -93,8 +92,7 @@ Task("GetVersion")
     Information("Determining version number");
     Information(System.IO.Directory.GetCurrentDirectory());
 
-    var cliDir = Path.Combine(unpackFolderFullPath, "Amazon", "AWSCLI");
-    //Information(cliDir);
+    var cliDir = Path.Combine(unpackFolderFullPath, "Amazon", "AWSCLIV2");
     var processArgumentBuilder = new ProcessArgumentBuilder();
     processArgumentBuilder.Append("--version");
     var processSettings = new ProcessSettings 
@@ -108,7 +106,7 @@ Task("GetVersion")
     IEnumerable<string> errorOutput;
 
     StartProcess(Path.Combine(cliDir, "aws.exe"), processSettings, out standardOutput, out errorOutput);
-    var outputLine = errorOutput.First();
+    var outputLine = standardOutput.First();
     Information($"Version output is \"{outputLine}\"");
     var regexMatch = Regex.Match(outputLine, @"aws-cli\/(?<Version>[\d\.]*)");
     nugetVersion = regexMatch.Groups["Version"].Value;
@@ -170,11 +168,7 @@ Task("FullChain")
 
 Task("Default").Does(() => 
 {  
-    foreach (var f in files)
-    {
-        file = f;
-        RunTarget("FullChain");
-    }
+    RunTarget("FullChain");
 });
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Attempting to run an old AWS CLI executable errors with 'failed to create process.'
Last successful build ran on CI was 3+ years ago, under a **win2012** agent. win2012 agents are long gone, and running on a windows 2019 agent fails.

I don't think fixing (if at all possible) to a particular cli version would be any useful, as there is little to no value in maintaining our builds in the first place (as it's already built).

**Changes**
* Updates AWSCLI version.

**Before**
(This is after fixing the path to the exe):
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/97423717/196939334-4e96e2e1-86db-4e6f-b49a-304369960759.png">

You can also test this by going into invoking the executable inside the extracted msi inside `build\temp\...\aws.exe`

**After**
<img width="1356" alt="image" src="https://user-images.githubusercontent.com/97423717/196939809-07b0615f-686b-4645-9a84-d0348cdda8b0.png">

### Draft
I'm leaving this as draft for now, until we measure the impact of this change.
