### PR TITLE
Update build script to align with latest AWSCLI v1 Package Shape

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -51,13 +51,6 @@ Task("Clean")
     CleanDirectory(artifactsDir);
 });
 
-// Task("Restore-NuGet-Packages")
-//     .IsDependentOn("Clean")
-//     .Does(() =>
-// {
-//     NuGetRestore("./src/Example.sln");
-// });
-
 Task("Restore-Source-Package")
     .IsDependentOn("Clean")
     .Does(() => 
@@ -93,8 +86,7 @@ Task("GetVersion")
     Information("Determining version number");
     Information(System.IO.Directory.GetCurrentDirectory());
 
-    var cliDir = Path.Combine(unpackFolderFullPath, "Amazon", "AWSCLI");
-    //Information(cliDir);
+    var cliDir = Path.Combine(unpackFolderFullPath, "Amazon", "AWSCLI", "bincompat");
     var processArgumentBuilder = new ProcessArgumentBuilder();
     processArgumentBuilder.Append("--version");
     var processSettings = new ProcessSettings 
@@ -107,8 +99,8 @@ Task("GetVersion")
     IEnumerable<string> standardOutput;
     IEnumerable<string> errorOutput;
 
-    StartProcess(Path.Combine(cliDir, "aws.exe"), processSettings, out standardOutput, out errorOutput);
-    var outputLine = errorOutput.First();
+    StartProcess(Path.Combine(cliDir, "aws.cmd"), processSettings, out standardOutput, out errorOutput);
+    var outputLine = standardOutput.First();
     Information($"Version output is \"{outputLine}\"");
     var regexMatch = Regex.Match(outputLine, @"aws-cli\/(?<Version>[\d\.]*)");
     nugetVersion = regexMatch.Groups["Version"].Value;


### PR DESCRIPTION
The shape and behaviour of the AWS CLI installer contents has changed. This build script is tightly coupled with that shape, so updating it to work with the latest version(s).

## Before
The build pipeline for this tool currently fails. It has not had nightly builds, so at some stage, the AWS team changed where the contents of the AWS CLI files live. This drifted from the way we used to calculate the version of the CLI tool, causing build failures.

```
13:02:06   ========================================
13:02:06   Restore-Source-Package
13:02:06   ========================================
13:02:06   Downloading https://s3.amazonaws.com/aws-cli/AWSCLI64.msi
13:02:15   
13:02:15   ========================================
13:02:15   Unpack-Source-Package
13:02:15   ========================================
13:02:15   Unpacking AWSCLI64.msi
13:04:21   Unpacked AWSCLI64.msi to C:\BuildAgent\work\2e35f96a8ddb737d\build\temp
13:04:21   
13:04:21   ========================================
13:04:21   GetVersion
13:04:21   ========================================
13:04:21   Determining version number
13:04:21   C:\BuildAgent\work\2e35f96a8ddb737d
13:04:21   An error occurred when executing task 'GetVersion'.
13:04:21   
13:04:21   An error occurred when executing task 'Default'.
13:04:21   ----------------------------------------
13:04:21   Teardown
13:04:21   ----------------------------------------
13:04:21   Finished running tasks.
13:04:21   
13:04:21   ----------------------------------------
13:04:21   Teardown
13:04:21   ----------------------------------------
13:04:21   Finished running tasks.
13:04:21   Error: One or more errors occurred.
13:04:21     The system cannot find the file specified
13:04:21   Process exited with code 1
13:04:21   Process exited with code 1 (Step: Run Cake (Command Line))
13:04:21   Step Run Cake (Command Line) failed
```

## After
The build passes


## Links
[SC-10645]
